### PR TITLE
added optional data decoding when reading from contract

### DIFF
--- a/tasks/on-demand-api-consumer/read-latest.js
+++ b/tasks/on-demand-api-consumer/read-latest.js
@@ -26,7 +26,38 @@ task(
         let latestRequestId = await apiConsumerContract.latestRequestId()
         let latestResponse = await apiConsumerContract.latestResponse()
         let latestError = await apiConsumerContract.latestError()
-        console.log("Data is: ", latestResponse.toString())
+        let responseStr = latestResponse.toString()
+
+        console.log(`💾 On-chain data represented as a hex string: ${responseStr}`)
+
+        const config = require('../../on-demand-request-config')
+        if (config.expectedReturnType) {
+            let decodedData
+            switch (config.expectedReturnType) {
+                case 'uint256':
+                    decodedData = BigInt('0x' + responseStr.slice(2).slice(-64));
+                    break
+                case 'int256':
+                    decodedData = signedInt256toBigInt('0x' + responseStr.slice(2).slice(-64));
+                    break
+                case 'string':
+                    decodedData = Buffer.from(responseStr.slice(2), 'hex').toString();
+                    break
+                default:
+                    const end = config.expectedReturnType;
+                    throw new Error(`incorrect expectedReturnType ${end}`);
+            }
+            console.log(`📒 On-chain data decoded as a ${config.expectedReturnType}: ${decodedData}`)
+        }
     })
+
+const signedInt256toBigInt = (hex) => {
+    const binary = BigInt(hex).toString(2).padStart(256, '0');
+    // if the first bit is 0, number is positive
+    if (binary[0] === '0') {
+        return BigInt(hex);
+    }
+    return -(BigInt(2) ** BigInt(255)) + BigInt(`0b${binary.slice(1)}`);
+}
 
 module.exports = {}


### PR DESCRIPTION
Added the optional ability to decode on-chain data to the expected type specified in the `on-demand-request-config.js` file.